### PR TITLE
Filter out statefulset labels from the rest

### DIFF
--- a/.pipeline/lib/deploy.js
+++ b/.pipeline/lib/deploy.js
@@ -94,16 +94,14 @@ module.exports = (settings)=>{
     }
   }))
   // filter out stateful set from the rest but keep 
-  const [ objectsLessStatefulSet, statefulSets ] = objects.reduce((acc, object) => {
-    if(acc.length === 0) acc = [[], []];
-    
+  const { objectsLessStatefulSet, statefulSets } = objects.reduce((acc, object) => {
     if(object.kind === 'StatefulSet') {
-      acc[1].push(object);
+      acc.statefulSets.push(object);
     } else {
-      acc[0].push(object);
+      acc.objectsLessStatefulSet.push(object);
     }
-    return object;
-  }, []);
+    return acc;
+  }, { objectsLessStatefulSet: [], statefulSets: [] });
 
   oc.applyRecommendedLabels(objectsLessStatefulSet, phases[phase].name, phase, `${changeId}`, phases[phase].instance)
   

--- a/.pipeline/lib/deploy.js
+++ b/.pipeline/lib/deploy.js
@@ -95,20 +95,22 @@ module.exports = (settings)=>{
   }))
   // filter out stateful set from the rest but keep 
   const [ objectsLessStatefulSet, statefulSets ] = objects.reduce((acc, object) => {
+    if(acc.length === 0) acc = [[], []];
+    
     if(object.kind === 'StatefulSet') {
       acc[1].push(object);
     } else {
       acc[0].push(object);
     }
     return object;
-  }, [[], []]);
+  }, []);
 
   oc.applyRecommendedLabels(objectsLessStatefulSet, phases[phase].name, phase, `${changeId}`, phases[phase].instance)
   
   const backup = [];
   const upgraded = [];
   objects = objectsLessStatefulSet.concat(statefulSets);
-  
+
   objects.forEach((item)=>{
     if (item.kind == 'StatefulSet' && item.metadata.labels["app.kubernetes.io/name"] === "patroni"){
       // oc.copyRecommendedLabels(item.metadata.labels, item.spec.selector.matchLabels)


### PR DESCRIPTION
modify the bcdk scripts so that the patroni stateful set does not get the same pr labels the rest of the objects do. This will prevent the auto deployment of patroni. 

I think there maybe a bug introduced with the cleanup script. I'm going to run it manually to test. 