### PR TITLE
Dockerhub account update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ oc process -f openshift/sso74-x509-secrets.yaml -p 'NAME=template.sso' -p 'SUFFI
 oc delete secret -l part-of=rh-sso,shared=true
 
 ```
+
+Additionally, a secret must be created to set up the docker account. In your namespace, run the command 
+    ```oc create secret docker-registry <secret-name> --docker-server=docker.io --docker-username=<docker-username> --docker-password=<docker-password> --docker-email=unused```
+
+Then link your secret with the command
+    ```oc process -f ./openshift/k6/sa-linked-image-pull-secrets.yaml -p NAMESPACE=<namespace> -p SECRET_NAME=<secret-name> | oc apply -f - -n <namespace>```
+
 ## Building
 ```
 cd .pipeline && ./npmw build -- --pr=9

--- a/openshift/k6/sa-linked-image-pull-secrets.yaml
+++ b/openshift/k6/sa-linked-image-pull-secrets.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: link-${SECRET_NAME}-template
+objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  imagePullSecrets: 
+  - name: ${SECRET_NAME}
+  metadata:
+    name: builder
+    namespace: ${NAMESPACE}
+- apiVersion: v1
+  kind: ServiceAccount
+  imagePullSecrets: 
+  - name: ${SECRET_NAME}
+  metadata:
+    name: default
+    namespace: ${NAMESPACE}
+parameters:
+- description: Namespace
+  displayName: namespace
+  name: NAMESPACE
+  required: true
+- description: Secret Name
+  displayName: Secret Name
+  name: SECRET_NAME
+  required: true


### PR DESCRIPTION
The Docker account to pull images needs to be updated to the paid Docker account `bcdevopscluster` to solve the rate-limit issue.

Instructions to create the secret and template file to link the secret has been added.