### PR TITLE
update default cpu requests for services

### DIFF
--- a/openshift/sso74-x509-postgresql.yaml
+++ b/openshift/sso74-x509-postgresql.yaml
@@ -331,11 +331,11 @@ parameters:
 - description: Container CPU limit.
   displayName: Container CPU Limit
   name: CPU_LIMIT
-  value: 500m
+  value: 750m
 - description: Container CPU request.
   displayName: Container CPU Request
   name: CPU_REQUEST
-  value: 250m
+  value: 500m
 - description: The OpenShift Namespace where the patroni and postgresql ImageStream
     resides.
   displayName: ImageStream Namespace

--- a/openshift/sso74-x509.yaml
+++ b/openshift/sso74-x509.yaml
@@ -335,7 +335,7 @@ parameters:
 - description: Container CPU request.
   displayName: Container CPU Request
   name: CPU_REQUEST
-  value: "1"
+  value: "1250m"
 - description: Set route with specific host.
   displayName: Host route
   name: HOST


### PR DESCRIPTION
As per unscheduled maintenance (https://github.com/bcgov/ocp-sso/wiki/2.2.2-SSO-and-DB-Hot-Fix-Manual-Steps). I've updated the default cpu requests to reflect the cpu requests in the production deployment for sso